### PR TITLE
Fix not starting on a new line when appending after previous run

### DIFF
--- a/pikaptcha/console.py
+++ b/pikaptcha/console.py
@@ -158,3 +158,6 @@ def entry():
             except Exception:
                 import traceback
                 print("Generic Exception: " + traceback.format_exc())
+        with open(args.textfile, "a") as ulist:
+            ulist.write("\n")
+            ulist.close()


### PR DESCRIPTION
This will append a new line character at the end of the output file, after all the accounts have been written out. Thus, when running again on the same file, the new output will start on a new line.
