### PR TITLE
Proxy to use to accept the ToS

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ You can type `pikaptcha --help` to see all parameters. Optional parameters are a
 	--startnum, -sn #If you use -c and -u, it will start counting from this number instead
 	--captchatimeout, -ct #If you want captcha to timeout of after n seconds	
 	--inputtext, -it #If you want to read user:pass from file
+	--proxy, -px #Proxy to be used when accepting the Terms of Services. Must be host:port (ex. 1.1.1.1:80). Must be a HTTPS proxy.
 ```
 
 Example 1 : Create an entirely random account by manually entering the captcha yourself
@@ -220,6 +221,11 @@ james:passn
 ```
 ```
 pikaptcha -it C:\user\sri\desktop\inputaccs.txt
+```
+
+Example 16 : Use proxy when accepting the Terms of Services.
+```
+pikaptcha -px 1.1.1.1:80
 ```
 	  
 ## Common Issues

--- a/pikaptcha/console.py
+++ b/pikaptcha/console.py
@@ -86,6 +86,10 @@ def parse_arguments(args):
     parser.add_argument(
         '-l','--location', type=str, default="40.7127837,-74.005941",
         help='This is the location that will be spoofed when we verify TOS'
+    )
+    parser.add_argument(
+        '-px','--proxy', type=str, default=None,
+        help='Proxy to be used when accepting the Terms of Services. Must be host:port (ex. 1.1.1.1:80). Must be a HTTPS proxy.'
     )        
 
     return parser.parse_args(args)
@@ -158,8 +162,8 @@ def entry():
                     print('  Password:  {}'.format(account_info["password"]))
                     print('  Email   :  {}'.format(account_info["email"]))
                     
-                    # Accespt Terms Service
-                    accept_tos(account_info["username"], account_info["password"], args.location)
+                    # Accept Terms Service
+                    accept_tos(account_info["username"], account_info["password"], args.location, args.proxy)
         
                     # Verify email
                     if (args.autoverify == True):

--- a/pikaptcha/console.py
+++ b/pikaptcha/console.py
@@ -158,7 +158,7 @@ def entry():
                     print('  Password:  {}'.format(account_info["password"]))
                     print('  Email   :  {}'.format(account_info["email"]))
                     
-                    # Accept Terms Service
+                    # Accespt Terms Service
                     accept_tos(account_info["username"], account_info["password"], args.location)
         
                     # Verify email

--- a/pikaptcha/tos.py
+++ b/pikaptcha/tos.py
@@ -5,26 +5,41 @@ from pgoapi.utilities import f2i
 from pgoapi import utilities as util
 from pgoapi.exceptions import AuthException, ServerSideRequestThrottlingException, NotLoggedInException
 
-def accept_tos(username, password, location):
+def accept_tos(username, password, location, proxy):
     try:
-        accept_tos_helper(username, password, location)
+        accept_tos_helper(username, password, location, proxy)
     except ServerSideRequestThrottlingException as e:
         print('Server side throttling, Waiting 10 seconds.')
         time.sleep(10)
-        accept_tos_helper(username, password, location)
+        accept_tos_helper(username, password, location, proxy)
     except NotLoggedInException as e1:
         print('Could not login, Waiting for 10 seconds')
         time.sleep(10)
-        accept_tos_helper(username, password, location)
+        accept_tos_helper(username, password, location, proxy)
 
-def accept_tos_helper(username, password, location):
+def accept_tos_helper(username, password, location, proxy):
+    print "Trying to accept Terms of Service for {}.".format(username)
+    failMessage = "Maybe the HTTPS proxy is not working? {} did not accept Terms of Service.".format(username)
+
     api = PGoApi()
+    if proxy != None:
+        api.set_proxy({"https":proxy})
+
     location = location.replace(" ", "")
     location = location.split(",")
     api.set_position(float(location[0]), float(location[1]), 0.0)
-    api.login('ptc', username, password)
+    api.set_authentication(provider = 'ptc', username = username, password = password)
+    response = api.app_simulation_login()
+    if response == None:
+        print "Servers do not respond to login attempt." + failMessage
+        return
+
     time.sleep(1)
     req = api.create_request()
     req.mark_tutorial_complete(tutorials_completed = 0, send_marketing_emails = False, send_push_notifications = False)
     response = req.call()
+    if response == None:
+        print "Servers do not respond to accepting the ToS." + failMessage
+        return
+
     print('Accepted Terms of Service for {}'.format(username))

--- a/pikaptcha/tos.py
+++ b/pikaptcha/tos.py
@@ -31,7 +31,7 @@ def accept_tos_helper(username, password, location, proxy):
     api.set_authentication(provider = 'ptc', username = username, password = password)
     response = api.app_simulation_login()
     if response == None:
-        print "Servers do not respond to login attempt." + failMessage
+        print "Servers do not respond to login attempt. " + failMessage
         return
 
     time.sleep(1)
@@ -39,7 +39,7 @@ def accept_tos_helper(username, password, location, proxy):
     req.mark_tutorial_complete(tutorials_completed = 0, send_marketing_emails = False, send_push_notifications = False)
     response = req.call()
     if response == None:
-        print "Servers do not respond to accepting the ToS." + failMessage
+        print "Servers do not respond to accepting the ToS. " + failMessage
         return
 
     print('Accepted Terms of Service for {}'.format(username))


### PR DESCRIPTION
You can now set HTTPS proxy with -px or --proxy flag, and the proxy will then be used when accepting the  ToS.

Make sure you have up-to-date version of `https://github.com/pogodevorg/pgoapi` installed. 
