### PR TITLE
Add support of forwarded plusmails

### DIFF
--- a/pikaptcha/console.py
+++ b/pikaptcha/console.py
@@ -60,8 +60,12 @@ def parse_arguments(args):
         help='Your 2captcha key from settings'
     )
     parser.add_argument(
+        '-gm', '--googlemail', type=str, default=None,
+        help='This is the mail for the google account when auto verify is activate (Only required if plus mail is different from google mail)'
+    )
+    parser.add_argument(
         '-gp','--googlepass', type=str, default=None,
-        help='This is the password for the google account you are using with plusmail'
+        help='This is the password for the google account and is require to activate auto verify when using the plus mail'
     )    
     parser.add_argument(
         '-t','--textfile', type=str, default="usernames.txt",
@@ -95,10 +99,8 @@ def parse_arguments(args):
     return parser.parse_args(args)
 
 def _verify_autoverify_email(settings):
-    if (settings['args'].autoverify == True and settings['args'].plusmail == None):
-        raise PTCInvalidEmailException("You have to specify a plusmail (--plusmail or -m) to use autoverification.")
-    if (settings['args'].autoverify == True and settings['args'].googlepass == None):
-        raise PTCInvalidEmailException("You have to specify a googlepass (--googlepass or -gp) to use autoverification.")
+    if (settings['args'].googlepass is not None and settings['args'].plusmail == None and settings['args'].googlemail == None):
+        raise PTCInvalidEmailException("You have to specify a plusmail (--plusmail or -m) or a google email (--googlemail or -gm) to use autoverification.")
 
 def _verify_plusmail_format(settings):
     if (settings['args'].plusmail != None and not re.match(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)", settings['args'].plusmail)):
@@ -140,7 +142,7 @@ def entry():
         args.count = len(lines)
         
     if _verify_settings({'args':args, 'balance':captchabal}):
-        if (args.autoverify == True):
+        if (args.googlepass is not None):
             with open(args.textfile, "a") as ulist:
                 ulist.write("The following accounts use the email address: " + args.plusmail + "\n")
                 ulist.close()
@@ -166,9 +168,12 @@ def entry():
                     accept_tos(account_info["username"], account_info["password"], args.location, args.proxy)
         
                     # Verify email
-                    if (args.autoverify == True):
-                        email_verify(args.plusmail, args.googlepass)
-                    
+                    if (args.googlepass is not None):
+                        if (args.googlemail is not None):
+                            email_verify(args.googlemail, args.googlepass)
+                        else:
+                            email_verify(args.plusmail, args.googlepass)
+
                     # Append usernames 
                     with open(args.textfile, "a") as ulist:
                         if args.outputformat == "pkgo":


### PR DESCRIPTION
This pull is based on the issue https://github.com/sriyegna/Pikaptcha/issues/76 and the pull https://github.com/sriyegna/Pikaptcha/pull/77.

Changes:
1. `--autoverify` is removed. `--googlepass` is used to enable automatic verify and enter the Google password.
2. The option `--googlemail` has been added so it is possible to use other plus mail addresses such as Hotmail.

How to use Hotmail as plus mail:
1. Go to your Hotmail webpage (https://outlook.live.com).
2. Click the gear at the top right of the page.
3. Select the `Option`.
4. On the left side click `Mail`, `Automatic processing` and then `Inbox rules`.
5. Press the `+` sign to add a rule.
6. Name it whatever you would like.
7. In the drop down menu below `When a message arrives, and:` select `It includes these words`
and then select `in the subject`.
8. Type `Pokémon Trainer Club Activation` into the top box and press the `+` and then `Ok`.
9. In the next drop down menu below `Do the following:` select `Forward, redirect or send` and then `Redirect this message to`.
10. Enter the the gmail you wish to use and press `Ok`.
11. Press `Ok` at the top and then press `Save` at the top.

**ATTENTION!!**
This feature will not work without this fix https://github.com/sriyegna/Pikaptcha/pull/80
